### PR TITLE
Add metacritic scores to cinemark hoyts

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -1,0 +1,43 @@
+## Cinemark Hoyts Metacritic Scores (Chrome MV3 Extension)
+
+Displays Metacritic critic and user scores on movie tiles at `https://www.cinemarkhoyts.com.ar/`.
+
+### Install (Developer Mode)
+
+1. Download or clone this folder to your machine.
+2. Open Chrome → go to `chrome://extensions`.
+3. Enable "Developer mode" (top-right).
+4. Click "Load unpacked" and select the `/workspace/extension` folder.
+5. Visit `https://www.cinemarkhoyts.com.ar/` and browse listings; scores appear top-right on each movie card.
+
+### How it works
+
+- A content script (`content.js`) detects movie tiles on the page, extracts their titles, and asks the background service worker for Metacritic scores.
+- The background worker (`background.js`) fetches from Metacritic using multiple strategies:
+  - Direct movie slug guess (e.g., `/movie/<slug>`)
+  - Search fallback, then follow the first movie result
+  - Mirror fallback via `https://r.jina.ai/` (text proxy) to bypass strict HTML delivery in some contexts
+- Results are cached in `chrome.storage.local` for 14 days to reduce requests.
+
+### Files
+
+- `manifest.json`: MV3 configuration and permissions
+- `background.js`: Fetches and caches Metacritic scores
+- `content.js`: Finds titles on Cinemark Hoyts, injects score badges
+- `styles.css`: Visual styles for the small top-right badges
+
+### Permissions
+
+- Host permissions: `https://www.cinemarkhoyts.com.ar/*`, `https://www.metacritic.com/*`, `https://r.jina.ai/*`
+- Storage permission for local caching
+
+### Notes
+
+- Some titles might not have Metacritic pages; those will show placeholders ("MC …" / "USER …").
+- If Metacritic changes their markup, score extraction patterns may need updates.
+- The extension is designed to be resilient with multiple selectors and fallbacks.
+
+### Uninstall
+
+- Visit `chrome://extensions`, toggle off or remove the extension.
+

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,181 @@
+/*
+  Background service worker for fetching Metacritic scores with caching and fallbacks.
+*/
+
+const CACHE_TTL_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
+const STORAGE_KEY_PREFIX = "mc:title:";
+
+function normalizeTitle(rawTitle) {
+  if (!rawTitle) return "";
+  let title = String(rawTitle).toLowerCase();
+  // Remove locale/format qualifiers often used on AR cinema sites
+  const junkPatterns = [
+    /\b(3d|2d|imax|4dx|xd)\b/g,
+    /\b(subtitulad[oa]s?|sub\.?|doblad[oa]s?|castellano|español)\b/g,
+    /\b(reestreno|re\s?estreno|preestreno)\b/g,
+    /\b(edici[oó]n\s+especial)\b/g,
+  ];
+  for (const pattern of junkPatterns) title = title.replace(pattern, " ");
+
+  // Remove year in parentheses or brackets
+  title = title.replace(/[\[(]\s*\d{4}\s*[\])]/g, " ");
+  // Remove anything after a colon or dash (common subtitles in Spanish)
+  title = title.split(":")[0];
+  title = title.split(" - ")[0];
+
+  // Remove diacritics
+  title = title.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+  // Remove non alphanumerics except spaces
+  title = title.replace(/[^a-z0-9 ]+/g, " ");
+  // Collapse spaces
+  title = title.replace(/\s+/g, " ").trim();
+  // Remove leading articles in Spanish/English
+  title = title.replace(/^(la|el|los|las|the|a|an)\s+/i, "");
+  return title;
+}
+
+function titleToSlug(title) {
+  const t = normalizeTitle(title);
+  if (!t) return "";
+  return t.replace(/\s+/g, "-");
+}
+
+async function getFromCache(normalizedTitle) {
+  return new Promise((resolve) => {
+    chrome.storage.local.get([STORAGE_KEY_PREFIX + normalizedTitle], (res) => {
+      const entry = res[STORAGE_KEY_PREFIX + normalizedTitle];
+      if (!entry) return resolve(null);
+      if (Date.now() - (entry.timestamp || 0) > CACHE_TTL_MS) return resolve(null);
+      resolve(entry);
+    });
+  });
+}
+
+async function setCache(normalizedTitle, data) {
+  return new Promise((resolve) => {
+    const value = { ...data, timestamp: Date.now() };
+    chrome.storage.local.set({ [STORAGE_KEY_PREFIX + normalizedTitle]: value }, () => resolve());
+  });
+}
+
+async function fetchText(url) {
+  try {
+    const res = await fetch(url, {
+      // No custom headers; extensions cannot set restricted headers like User-Agent
+      credentials: "omit",
+      cache: "no-store",
+      redirect: "follow",
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return await res.text();
+  } catch (err) {
+    throw err;
+  }
+}
+
+function parseScoresFromMoviePage(html) {
+  // Try multiple patterns to be resilient to Metacritic markup changes
+  let critic = null;
+  let user = null;
+
+  const patternsCritic = [
+    /metascore_w[^>]*>(\d{2,3})<\/span>/i,
+    /c-siteReviewScore_num[^>]*>(\d{2,3})<\//i,
+    /c-productScoreInfo_scoreNumber[^>]*>(\d{2,3})<\//i,
+    /<span[^>]*data-v2-meta-score[^>]*>(\d{2,3})<\//i,
+  ];
+  const patternsUser = [
+    /metascore_w\s+user[^>]*>(\d(?:\.\d)?)<\/span>/i,
+    /c-siteReviewScoreUser_scoreNumber[^>]*>(\d(?:\.\d)?)<\//i,
+    /c-userScore_scoreNumber[^>]*>(\d(?:\.\d)?)<\//i,
+  ];
+
+  for (const re of patternsCritic) {
+    const m = html.match(re);
+    if (m && m[1]) { critic = parseInt(m[1], 10); break; }
+  }
+  for (const re of patternsUser) {
+    const m = html.match(re);
+    if (m && m[1]) { user = parseFloat(m[1]); break; }
+  }
+  return { critic, user };
+}
+
+function extractFirstMovieLinkFromSearch(html) {
+  // Find first link to /movie/<slug>
+  const linkMatch = html.match(/href=\"(\/movie\/[^\"?#]+)\"/i);
+  return linkMatch ? linkMatch[1] : null;
+}
+
+async function tryFetchMoviePageBySlug(slug) {
+  const urls = [
+    `https://www.metacritic.com/movie/${slug}`,
+    // Fallback via text mirror to bypass potential CORS/anti-bot
+    `https://r.jina.ai/http://www.metacritic.com/movie/${slug}`,
+  ];
+  for (const url of urls) {
+    try {
+      const html = await fetchText(url);
+      const { critic, user } = parseScoresFromMoviePage(html);
+      if (critic != null || user != null) return { critic, user };
+    } catch (_) { /* continue */ }
+  }
+  return null;
+}
+
+async function searchAndFetch(title) {
+  const q = encodeURIComponent(normalizeTitle(title));
+  const searchUrls = [
+    `https://www.metacritic.com/search/movie/${q}/results`,
+    `https://r.jina.ai/http://www.metacritic.com/search/movie/${q}/results`,
+    // Legacy search paths as fallbacks
+    `https://www.metacritic.com/search/all/${q}/results?cats=movies`,
+    `https://r.jina.ai/http://www.metacritic.com/search/all/${q}/results?cats=movies`,
+  ];
+  for (const url of searchUrls) {
+    try {
+      const html = await fetchText(url);
+      const link = extractFirstMovieLinkFromSearch(html);
+      if (link) {
+        const slug = link.split("/movie/")[1];
+        const res = await tryFetchMoviePageBySlug(slug);
+        if (res) return res;
+      }
+    } catch (_) { /* continue */ }
+  }
+  return null;
+}
+
+async function getScoresForTitle(title) {
+  const normalized = normalizeTitle(title);
+  if (!normalized) return { critic: null, user: null };
+
+  const cached = await getFromCache(normalized);
+  if (cached) return { critic: cached.critic ?? null, user: cached.user ?? null };
+
+  // Try direct slug guess first
+  const slug = titleToSlug(title);
+  let result = null;
+  if (slug) {
+    result = await tryFetchMoviePageBySlug(slug);
+  }
+  if (!result) {
+    result = await searchAndFetch(title);
+  }
+
+  const finalResult = result || { critic: null, user: null };
+  await setCache(normalized, finalResult);
+  return finalResult;
+}
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message && message.type === "GET_METACRITIC_SCORES") {
+    const { title } = message;
+    getScoresForTitle(title)
+      .then((res) => sendResponse({ ok: true, data: res }))
+      .catch((err) => sendResponse({ ok: false, error: String(err) }));
+    return true; // indicates async response
+  }
+  return false;
+});
+

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,0 +1,150 @@
+/*
+  Content script: scans Cinemark Hoyts pages for movie tiles and injects
+  Metacritic critic and user score badges in the top-right corner of each tile.
+*/
+
+(function () {
+  const BADGE_CLASS = "ch-mc-badge";
+  const BADGE_WRAPPER_CLASS = "ch-mc-badge-wrapper";
+  const SCANNED_ATTR = "data-ch-mc-scanned";
+
+  function debounce(fn, delay) {
+    let timer = null;
+    return function (...args) {
+      clearTimeout(timer);
+      timer = setTimeout(() => fn.apply(this, args), delay);
+    };
+  }
+
+  function selectTitleFromCard(card) {
+    // Preferred: <img alt="Title"> inside the card
+    const img = card.querySelector("img[alt]");
+    if (img && img.getAttribute("alt") && img.getAttribute("alt").trim().length > 0) {
+      return img.getAttribute("alt").trim();
+    }
+    // Try headings
+    const heading = card.querySelector("h1, h2, h3, .title, [class*='title'], [data-title]");
+    if (heading) {
+      const dt = heading.getAttribute("data-title");
+      return (dt || heading.textContent || "").trim();
+    }
+    // Fallback to link text
+    const link = card.querySelector("a[href]");
+    if (link) return (link.getAttribute("aria-label") || link.textContent || "").trim();
+    return "";
+  }
+
+  function findMovieCards() {
+    const candidates = new Set();
+    // Common patterns on cinemarkhoyts.com.ar for movie/listing/detail tiles
+    const linkNodes = document.querySelectorAll(
+      "a[href*='/peliculas/'], a[href*='/pelicula/'], a[href*='/peliculas?']"
+    );
+    linkNodes.forEach((a) => {
+      const card = a.closest("article, li, .card, .movie, .pelicula, .grid-item, .swiper-slide, .slick-slide, .card-body, .card-container");
+      if (card) candidates.add(card);
+    });
+
+    // Also consider visible images with alt text (covers)
+    const imgs = document.querySelectorAll("img[alt]");
+    imgs.forEach((img) => {
+      const card = img.closest("article, li, .card, .movie, .pelicula, .grid-item, .swiper-slide, .slick-slide, .card-body, .card-container");
+      if (card) candidates.add(card);
+    });
+
+    // Filter only those with a plausible title
+    return Array.from(candidates).filter((card) => selectTitleFromCard(card));
+  }
+
+  function ensurePositioning(card) {
+    const style = window.getComputedStyle(card);
+    if (style.position === "static") {
+      card.style.position = "relative";
+    }
+  }
+
+  function createBadgeWrapper(card) {
+    let wrapper = card.querySelector(`.${BADGE_WRAPPER_CLASS}`);
+    if (!wrapper) {
+      wrapper = document.createElement("div");
+      wrapper.className = BADGE_WRAPPER_CLASS;
+      card.appendChild(wrapper);
+    }
+    return wrapper;
+  }
+
+  function scoreToColor(score100) {
+    if (score100 == null || isNaN(score100)) return "#888";
+    if (score100 >= 61) return "#2ecc71"; // green
+    if (score100 >= 40) return "#f1c40f"; // yellow
+    return "#e74c3c"; // red
+  }
+
+  function renderBadge(wrapper, title, critic, user) {
+    // critic 0-100, user 0-10; we render both as-is but color by 100-scale
+    const criticColor = scoreToColor(typeof critic === "number" ? critic : null);
+    const user100 = typeof user === "number" ? Math.round(user * 10) : null;
+    const userColor = scoreToColor(user100);
+
+    wrapper.innerHTML = "";
+
+    const container = document.createElement("div");
+    container.className = BADGE_CLASS;
+    container.title = `Metacritic scores for ${title}`;
+
+    const criticEl = document.createElement("div");
+    criticEl.className = "ch-mc-pill ch-mc-critic";
+    criticEl.style.backgroundColor = criticColor;
+    criticEl.textContent = critic != null ? `MC ${critic}` : "MC …";
+
+    const userEl = document.createElement("div");
+    userEl.className = "ch-mc-pill ch-mc-user";
+    userEl.style.backgroundColor = userColor;
+    userEl.textContent = user != null ? `USER ${user.toFixed(1)}` : "USER …";
+
+    container.appendChild(criticEl);
+    container.appendChild(userEl);
+    wrapper.appendChild(container);
+  }
+
+  function requestScores(title) {
+    return new Promise((resolve) => {
+      chrome.runtime.sendMessage({ type: "GET_METACRITIC_SCORES", title }, (resp) => {
+        if (!resp || !resp.ok) return resolve({ critic: null, user: null });
+        resolve(resp.data || { critic: null, user: null });
+      });
+    });
+  }
+
+  async function processCard(card) {
+    if (card.getAttribute(SCANNED_ATTR) === "1") return;
+    const title = selectTitleFromCard(card);
+    if (!title) return;
+    ensurePositioning(card);
+    const wrapper = createBadgeWrapper(card);
+    renderBadge(wrapper, title, null, null); // show placeholders
+    card.setAttribute(SCANNED_ATTR, "1");
+    const { critic, user } = await requestScores(title);
+    renderBadge(wrapper, title, critic, user);
+  }
+
+  const scanAll = debounce(() => {
+    const cards = findMovieCards();
+    cards.forEach(processCard);
+  }, 200);
+
+  // Initial scan
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", scanAll);
+  } else {
+    scanAll();
+  }
+
+  // Observe dynamic content changes
+  const observer = new MutationObserver(() => scanAll());
+  observer.observe(document.documentElement || document.body, {
+    childList: true,
+    subtree: true,
+  });
+})();
+

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,31 @@
+{
+  "manifest_version": 3,
+  "name": "Cinemark Hoyts Metacritic Scores",
+  "version": "0.1.0",
+  "description": "Displays Metacritic critic and user scores on cinemarkhoyts.com.ar movie tiles.",
+  "action": {
+    "default_title": "Metacritic Scores"
+  },
+  "permissions": [
+    "storage"
+  ],
+  "host_permissions": [
+    "https://www.cinemarkhoyts.com.ar/*",
+    "https://www.metacritic.com/*",
+    "https://r.jina.ai/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "https://www.cinemarkhoyts.com.ar/*"
+      ],
+      "js": ["content.js"],
+      "css": ["styles.css"],
+      "run_at": "document_idle"
+    }
+  ],
+  "icons": {}
+}

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -1,0 +1,28 @@
+.ch-mc-badge-wrapper {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 10;
+  pointer-events: none;
+}
+
+.ch-mc-badge {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.ch-mc-pill {
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, sans-serif;
+  font-size: 11px;
+  line-height: 1;
+  color: #fff;
+  padding: 5px 6px;
+  border-radius: 999px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.35);
+  pointer-events: auto; /* allow tooltip hover */
+}
+
+.ch-mc-critic { background: #2ecc71; }
+.ch-mc-user { background: #3498db; }
+


### PR DESCRIPTION
Add a Chrome MV3 extension to display Metacritic critic and user scores on movie tiles at cinemarkhoyts.com.ar.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b3601ef-9f42-4ade-bc85-88acca1d232a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1b3601ef-9f42-4ade-bc85-88acca1d232a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

